### PR TITLE
Use floating point division

### DIFF
--- a/src/Crockford.elm
+++ b/src/Crockford.elm
@@ -43,7 +43,6 @@ import Crockford.Advanced as Advanced
   - `InvalidChecksum` means you tried to decode a base32 string with a checksum, but the checksum didn't match.
   - `InvalidCharacter` means you tried to decode a base32 string, but an invalid character was encountered.
   - `EmptyString` means you tried to decode an empty string.
-  - `NumberTooLarge` means you tried to encode a number that is too large to work with.
 
 -}
 type Error
@@ -51,7 +50,6 @@ type Error
     | InvalidChecksum
     | InvalidCharacter Char
     | EmptyString
-    | NumberTooLarge Int
 
 
 {-| Encode an integer as a base32 string.
@@ -116,6 +114,3 @@ mapError err =
 
         Advanced.EmptyString ->
             EmptyString
-
-        Advanced.NumberTooLarge n ->
-            NumberTooLarge n

--- a/src/Crockford/Advanced.elm
+++ b/src/Crockford/Advanced.elm
@@ -6,12 +6,16 @@ type Error
     | InvalidChecksum
     | InvalidCharacter Char
     | EmptyString
-    | NumberTooLarge Int
 
 
 base : Int
 base =
     32
+
+
+baseFloat : Float
+baseFloat =
+    toFloat base
 
 
 encode : { checksum : Bool } -> Int -> Result Error String
@@ -22,7 +26,7 @@ encode { checksum } x =
         encodeAsCharList n =
             let
                 div =
-                    n // base
+                    floor (toFloat n / baseFloat)
 
                 rem =
                     remainderBy base n
@@ -50,9 +54,6 @@ encode { checksum } x =
     if x < 0 then
         Err NegativeNumber
         -- For some large numbers, math starts to break down.
-
-    else if x // base < 0 then
-        Err (NumberTooLarge x)
 
     else
         encodeAsCharList x

--- a/tests/CrockfordTests.elm
+++ b/tests/CrockfordTests.elm
@@ -27,7 +27,7 @@ encodingTests =
                         364432432434209
                 in
                 encode n
-                    |> Expect.equal (Err (NumberTooLarge n))
+                    |> Expect.equal (Ok "ABEC4TW311")
         , test "fails on negative integers" <|
             \_ ->
                 Expect.equal (Err NegativeNumber) (encode -1)


### PR DESCRIPTION
This gets past the number size limits of integer division.